### PR TITLE
original scale fix

### DIFF
--- a/src/toolkit.js
+++ b/src/toolkit.js
@@ -119,9 +119,16 @@ export function transition($element, time) {
         replaceTransition($element, 'translate', time);
         replaceTransition($element, 'scale', time);
     } else {
-        replaceTransition($element, 'translate', null);
-        replaceTransition($element, 'scale', null);
+        removeTransition($element);
     }
+}
+
+/**
+ * @param {HTMLElement} $element
+ */
+export function removeTransition($element) {
+    replaceTransition($element, 'translate', null);
+    replaceTransition($element, 'scale', null);
 }
 
 /**
@@ -130,31 +137,32 @@ export function transition($element, time) {
  * @param {?number} time
  */
 function replaceTransition($element, property, time) {
-    const css = $element.style.transition;
-    const regex = RegExp(/(^|\s)/ + property + /\s\d+s($|,)/, 'i');
+    const st = $element.style
+    const css = st.transition;
+    const regex = RegExp(property + "[^,]+", 'i');
 
     if (time !== null) {
         const rule = `${ property } ${ time }s`;
 
         if (!css) {
             // create definition
-            $element.style.transition = rule;
+            st.transition = rule;
         } else if (css.includes(property)) {
             // change existing rule in the definition
-            $element.style.transition.replace(regex, rule);
+            st.transition = css.replace(regex, rule);
         } else {
             // append to an existing definition
-            $element.style.transition += `, ${ rule }`;
+            st.transition += `, ${ rule }`;
         }
     } else {
         if (css.includes(property)) {
             // remove rule from the definition
-            $element.style.transition.replace(regex, '');
+            st.transition = css.replace(RegExp(regex.source + ",?"), '');
         }
 
-        if (!$element.style.transition) {
+        if (!st.transition) {
             // clean up the definition if not needed
-            $element.style.removeProperty('transition');
+            st.removeProperty('transition');
         }
     }
 }

--- a/src/wheel-zoom.js
+++ b/src/wheel-zoom.js
@@ -9,7 +9,7 @@ import {
     isTouch,
     transition,
     transform,
-} from './toolkit';
+    removeTransition
 import {
     calculateAlignPoint,
     calculateContentMaxShift,
@@ -190,8 +190,23 @@ WZoom.prototype = {
             content.originalHeight = options.height || content.$element.offsetHeight;
         }
 
-        const scale = content.$element.style.scale;
-        content.originalScale = scale ? scale.split(' ').map(p => parseFloat(p)) : [ 1, 1, 1 ];
+        // Parse the original scale to the full canonical form ( = 3 numbers)
+        // Note that the scale must be set directly to the element in the HTML,
+        // not via an inherited CSS rule.
+        // Ex: Set via `img.style.scale = '1 -1';`, not via `#img { scale: 1 -1; }`,
+        const scale = content.$element.style.scale.split(" ").map(v => parseFloat(v));
+        content.originalScale = (() => {
+            switch (scale.length) {
+                case 1:
+                    if (isNaN(scale[0])) { // no scale defined (empty string to float produced NaN)
+                        return [1,1,1];
+                    }
+                    return [scale[0],scale[0],1]; // single value → X used for X and Y
+                case 2: // two values → used for X and Y
+                    return [scale[0],scale[1],1];
+                case 3: // all X, Y, Z values defined
+                    return scale;
+        }})()
         content.originalTranslateZ = content.$element.style.translate?.split(' ')[2] || '0px';
 
         content.maxScale = options.maxScale;
@@ -322,6 +337,9 @@ WZoom.prototype = {
         }
     },
     prepare() {
+        // Before reinitializing the script, we need to restore the original CSS
+        // so that the actual zoomed CSS is not mistaken for the original one.
+        this.restoreElement();
         this._prepare();
     },
     /**
@@ -362,12 +380,33 @@ WZoom.prototype = {
     maxZoomUpToPoint(coordinates) {
         this._zoom(this.content.maxScale, coordinates);
     },
+    restoreElement() {
+        const {$element, originalScale, originalTranslateZ} = this.content;
+
+        // restore the scale
+        if(originalScale.every(v => v  === 1)) { // there was just the default scale, remove the property altogether
+            $element.style.removeProperty('scale');
+        } else { // there was an original scale that needs to be restored
+            $element.style.scale = `${ originalScale[0] } ${ originalScale[1]  } ${ originalScale[2] }`
+        }
+
+        // restore the translation
+        if(originalTranslateZ === "0px") { // keep translate-Z if specified
+            $element.style.removeProperty('translate');
+        } else {
+            $element.style.translate = "0 0 " + originalTranslateZ;
+        }
+
+
+    },
     destroy() {
-        this.content.$element.style.removeProperty('transition');
-        this.content.$element.style.removeProperty('transform');
+        const $el = this.content.$element;
+
+        this.restoreElement();
+        removeTransition($el);
 
         if (this.options.type === 'image') {
-            off(this.content.$element, 'load', this._init);
+            off($el, 'load', this._init);
         }
 
         this._destroyObservers();
@@ -420,8 +459,8 @@ export default WZoom;
  * @property {HTMLElement} [$element]
  * @property {number} [originalWidth]
  * @property {number} [originalHeight]
- * @property {number[]} [originalScale]
- * @property {string} [originalTranslateZ]
+ * @property {[number,number,number]} [originalScale]
+ * @property {string} [originalTranslateZ] Original Z value. Cannot be reduced to number due to the unit.
  * @property {number} [currentWidth]
  * @property {number} [currentHeight]
  * @property {number} [currentLeft]


### PR DESCRIPTION
This pull addresses the issue from my previous proposal #49 . That was entirely my bad. As we needed to change the underlying picture, we parsed the currently zoomed scale for the original scale. Moreover, I had a bug in the scale property parsing. (Because [it may contain](https://developer.mozilla.org/en-US/docs/Web/CSS/scale) 1, 2 or 3 values).

I tried all the examples now, every button, and my PR behaves me just the same as your original examples.
